### PR TITLE
Corrected the console logs of node client

### DIFF
--- a/node_client/index.js
+++ b/node_client/index.js
@@ -27,19 +27,19 @@ setInterval(()=> {
     })
 
   // BlockNumber
-  clientNodeTwo.call({"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1 },
+  clientNodeOne.call({"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1 },
     function(err, res) {
       if (err) console.log(err)
 
-      console.log("NODE TWO block number: " + parseInt(res.result, 16) )
+      console.log("NODE ONE block number: " + parseInt(res.result, 16) )
     })
   
   // Coinbase
-  clientNodeOne.call({"jsonrpc": "2.0", "method": "eth_coinbase", "params": [], "id": 0 },
+  clientNodeTwo.call({"jsonrpc": "2.0", "method": "eth_coinbase", "params": [], "id": 0 },
     function(err, res) {
       if (err) console.log(err)
 
-      console.log("NODE ONE coinbase: " + res.result )
+      console.log("NODE TWO coinbase: " + res.result )
     })
   
   // blockNumber


### PR DESCRIPTION
It was always printing Node ONE coin base and Node TWO block numbers. IMO, we expect Node ONE coin base, Node ONE block number, Node TWO coin base & Node TWO block number.
This pull request contains that changes.
Please review and merge if you agree with the changes.